### PR TITLE
Multilingual site (ru/en) and English translations for latest posts

### DIFF
--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -1,0 +1,8 @@
+---
+menu:
+  main:
+    name: Home
+    weight: -100
+    params:
+      icon: home
+---

--- a/content/page/about/index.en.md
+++ b/content/page/about/index.en.md
@@ -1,0 +1,17 @@
+---
+title: About
+slug: about
+description: Golang developer, IT architect, and tech lead
+date: '2025-03-11'
+menu:
+  main:
+    weight: -90
+    params:
+      icon: user
+---
+
+Hi! I'm Igor, a Golang developer, IT architect, and tech lead.
+
+I enjoy Domain Driven Design (DDD), clean architecture,
+object-oriented programming, Test Driven Development (TDD),
+microservices, and more.

--- a/content/page/archives/index.en.md
+++ b/content/page/archives/index.en.md
@@ -1,0 +1,11 @@
+---
+title: "Archives"
+slug: "archives"
+date: 2019-05-28
+layout: "archives"
+menu:
+    main:
+        weight: -70
+        params:
+            icon: archives
+---

--- a/content/page/search/index.en.md
+++ b/content/page/search/index.en.md
@@ -1,0 +1,13 @@
+---
+title: "Search"
+slug: "search"
+layout: "search"
+outputs:
+    - html
+    - json
+menu:
+    main:
+        weight: -60
+        params:
+            icon: search
+---

--- a/content/page/slides/index.en.md
+++ b/content/page/slides/index.en.md
@@ -1,0 +1,11 @@
+---
+title: "Slides"
+slug: "slides"
+menu:
+    main:
+        weight: -80
+        params:
+            icon: presentation
+---
+
+* [Validation in Go](https://igorlazarev.ru/slides/validation)

--- a/content/post/2025-03-12-new-blog-life-with-hugo/index.en.md
+++ b/content/post/2025-03-12-new-blog-life-with-hugo/index.en.md
@@ -1,0 +1,58 @@
+---
+title: 'A new life for the blog on Hugo'
+slug: 'new-blog-life-with-hugo'
+translationKey: new-blog-life-with-hugo
+date: '2025-03-12T21:42:31+03:00'
+image: 'hugo-logo.svg'
+tags: ["news"]
+---
+
+I was moving sites to a new host and decided to dust off the shelves and work on my blog again.
+The previous version was powered by the static site generator [Jekyll](https://jekyllrb.com/).
+That was sometimes awkward: Ruby dependencies, and occasional vulnerability alerts from GitHub’s security bot
+(though for local work those were never critical). Meanwhile, [Hugo](https://gohugo.io/) kept popping up
+in Go-related Telegram channels.
+
+[Hugo](https://gohugo.io/) is a static site generator written in Go. According to the official site,
+it is “the world’s fastest framework for building websites.” Hugo ships as a normal binary
+(you can install it on Linux, macOS, or Windows) and includes a powerful templating system.
+
+To get started you pick a [theme](https://themes.gohugo.io/). I ended up liking
+[hugo-theme-stack](https://stack.jimmycai.com/): it is minimal without extra noise,
+has handy menus, categories, tags, and more—and the [documentation](https://stack.jimmycai.com/config/) is detailed.
+
+Next I adapted the repo on [GitHub](https://github.com/strider2038/igorlazarev-ru).
+I dropped the old Travis CI pipeline and replaced it with GitHub Actions. Finding actions
+for build and deploy took just a few minutes. I used [peaceiris/actions-hugo](https://github.com/marketplace/actions/hugo-setup)
+for the build and [SamKirkland/FTP-Deploy-Action](https://github.com/marketplace/actions/ftp-deploy)
+for FTP deploy to hosting. The result looks like this—simple and effective!
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true  # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.160.0'
+          extended: true
+
+      - name: Build
+        run: hugo --minify
+
+      - name: Deploy
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        with:
+          local-dir: ./public/
+          server: ${{ secrets.server }}
+          username: ${{ secrets.username }}
+          password: ${{ secrets.password }}
+```

--- a/content/post/2025-03-12-new-blog-life-with-hugo/index.md
+++ b/content/post/2025-03-12-new-blog-life-with-hugo/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Новая жизнь журнала на Hugo'
 slug: 'new-blog-life-with-hugo'
+translationKey: new-blog-life-with-hugo
 date: '2025-03-12T21:42:31+03:00'
 image: 'hugo-logo.svg'
 tags: ["news"]

--- a/content/post/2025-04-go-null-type-pattern/index.en.md
+++ b/content/post/2025-04-go-null-type-pattern/index.en.md
@@ -1,0 +1,341 @@
+---
+title: 'Reducing nil pointer panic risk with the Null Type pattern'
+slug: 'go-null-type-pattern'
+translationKey: go-null-type-pattern
+date: '2025-04-05'
+categories: ["Programming"]
+tags: ["Golang", "null", "typing", "pattern"]
+image: "poster.jpg"
+---
+
+In the previous [article](https://igorlazarev.ru/p/nullable-or-not-nullable/) (Russian) I looked at the risks of nullable types.
+In Go such data is usually modeled with pointer fields, but there are other approaches.
+This post covers the Null Type pattern, which reduces the chance of nil pointer panics.
+
+<!--more-->
+
+## Problem context
+
+Suppose we handle an HTTP request whose contract allows nullable types.
+The payload has two fields: `name` (`null` means “no name”)
+and `count` (`null` means “no count”). A JSON schema for this contract
+might look like this:
+
+```yaml
+type: object
+properties:
+  name:
+    type: [string, null]
+  count:
+    type: [object, null]
+    properties:
+      value:
+        type: integer
+      unit:
+        type: string
+```
+
+We can model that in Go as follows.
+
+```go
+type Request struct {
+    Name  *string `json:"name"`
+    Count *Count  `json:"count"`
+}
+
+type Count struct {
+    Value int    `json:"value"`
+    Unit  string `json:"unit"`
+}
+```
+
+Pointer fields demand care: you must always check for `nil`.
+
+```go
+var r Request
+
+// ...
+
+if r.Name != nil {
+    *r.Name = strings.TrimSpace(*r.Name)
+}
+
+if r.Name == nil {
+    fmt.Println("no name")
+} else {
+    fmt.Println("name: ", *r.Name)
+}
+
+if r.Count == nil {
+    fmt.Println("no count")
+} else {
+    fmt.Println("count: ", r.Count.Value, " ", r.Count.Unit)
+}
+```
+
+Comparing these fields is also non-trivial.
+
+```go
+func main() {
+    var r1, r2 Request
+    if EqualCount(r1.Count, r2.Count) {
+        fmt.Println("equal count")
+    }
+}
+
+func EqualCount(c1, c2 *Count) bool {
+    if c1 == nil && c2 == nil {
+        return true
+    }
+    if c1 == nil || c2 == nil {
+        return false
+    }
+    
+    return *c1 == *c2
+}
+```
+
+## Null Type pattern
+
+To lower nil pointer risk, you can use the Null Type pattern. Examples
+appear in the standard library ([`sql.NullString`](https://pkg.go.dev/database/sql#NullString),
+[`sql.NullInt64`](https://pkg.go.dev/database/sql#NullInt64)) and in popular packages
+(e.g. [google/uuid](https://pkg.go.dev/github.com/google/uuid#NullUUID)).
+The usual recipe is a dedicated type with methods for encoding and decoding:
+
+* `Scan()`, `Value()` — database encoding/decoding;
+* `MarshalJSON()`, `UnmarshalJSON()` — JSON;
+* `MarshalText()`, `UnmarshalText()` — text;
+* `MarshalBinary()`, `UnmarshalBinary()` — binary formats.
+
+Below is an implementation for our contract, assuming the types are used with JSON and a database.
+
+```go
+var jsonNull = []byte("null")
+
+type NullString struct {
+    String string
+    Valid  bool
+}
+
+func (s *NullString) Scan(value any) error {
+    var ns sql.NullString
+    if err := ns.Scan(value); err != nil {
+        return err
+    }
+
+    s.Valid = ns.Valid
+    s.String = ns.String
+
+    return nil
+}
+
+func (s NullString) Value() (driver.Value, error) {
+    if !s.Valid {
+        return nil, nil
+    }
+
+    return s.String, nil
+}
+
+func (s NullString) MarshalJSON() ([]byte, error) {
+    if !s.Valid {
+        return jsonNull, nil
+    }
+
+    return json.Marshal(s.String)
+}
+
+func (s *NullString) UnmarshalJSON(b []byte) error {
+    if bytes.Equal(b, jsonNull) {
+        s.String, s.Valid = "", false
+
+        return nil
+    }
+
+    if err := json.Unmarshal(b, &s.String); err != nil {
+        return err
+    }
+
+    s.Valid = true
+
+    return nil
+}
+```
+
+Because `Count` is composite and might map to two DB columns, we skip `Scan()` and `Value()` here
+and only add `MarshalJSON()` and `UnmarshalJSON()`.
+
+```go
+type NullCount struct {
+    Count Count
+    Valid bool
+}
+
+func (c NullCount) MarshalJSON() ([]byte, error) {
+    if !c.Valid {
+        return jsonNull, nil
+    }
+
+    return json.Marshal(c.Count)
+}
+
+func (c *NullCount) UnmarshalJSON(b []byte) error {
+    if bytes.Equal(b, jsonNull) {
+        c.Count, c.Valid = Count{}, false
+
+        return nil
+    }
+
+    if err := json.Unmarshal(b, &c.Count); err != nil {
+        return err
+    }
+
+    c.Valid = true
+
+    return nil
+}
+```
+
+## Usage example
+
+Rewriting the earlier snippet with the Null Type pattern:
+
+```go
+var r Request
+
+r.Name.String = strings.TrimSpace(r.Name.String)
+
+if !r.Name.Valid {
+    fmt.Println("no name")
+} else {
+    fmt.Println("name: ", r.Name.String)
+}
+
+if !r.Count.Valid {
+    fmt.Println("no count")
+} else {
+    fmt.Println("count: ", r.Count.Count.Value, " ", r.Count.Count.Unit)
+}
+
+var r1, r2 Request
+if r1.Count == r2.Count {
+    fmt.Println("equal count")
+}
+```
+
+What changed?
+
+* Some redundant `Valid` checks can go away (they used to be mandatory).
+* Core business logic still checks `Valid` where it matters.
+* Comparison becomes trivial: `r1.Count == r2.Count` (only if every field of the struct is `comparable`).
+* Field paths get longer: `r.Count.Count.Value`.
+
+Initialization is a bit more verbose.
+
+```go
+var r Request
+
+r.Name = NullString{Valid: true, String: "name"}
+r.Count = NullCount{Valid: true, Count: Count{Value: 1, Unit: "kg"}}
+```
+
+Constructors fix that.
+
+```go
+func NewNullString(s string) NullString {
+    return NullString{Valid: true, String: s}
+}
+
+func NewNullCount(value int, unit string) NullCount {
+    return NullCount{Valid: true, Count: Count{Value: value, Unit: unit}}
+}
+```
+
+Then:
+
+```go
+var r Request
+
+r.Name = NewNullString("name")
+r.Count = NewNullCount(1, "kg")
+```
+
+You can also add helpers or proxy methods.
+
+```go
+func (c NullCount) String() string {
+    if c.Valid {
+        return c.Count.String()
+    }
+
+    return ""
+}
+
+func (c NullCount) Add(next NullCount) (NullCount, error) {
+    if c.Valid && next.Valid {
+        sum, err := c.Count.Add(next.Count)
+        if err != nil {
+            return NullCount{}, err
+        }
+
+        return NullCount{Valid: true, Count: sum}, err
+    }
+    if c.Valid {
+        return NullCount{Valid: true, Count: c.Count}, nil
+    }
+    if next.Valid {
+        return NullCount{Valid: true, Count: next.Count}, nil
+    }
+
+    return NullCount{}, nil
+}
+```
+
+## Alternative
+
+The Null Type pattern is not the only option. With many fields it can hurt readability.
+If a pointer is acceptable for the whole struct, nil checks inside methods may be simpler—but you must:
+
+1) use pointer receivers on all methods;  
+2) guard the receiver against `nil` in every method.
+
+Example for `Count`:
+
+```go
+func (c *Count) String() string {
+    if c == nil {
+        return ""
+    }
+
+    return fmt.Sprintf("%d %s", c.Value, c.Unit)
+}
+
+func (c *Count) Add(next *Count) (*Count, error) {
+    if c != nil && next != nil {
+        if c.Unit != next.Unit {
+            return nil, fmt.Errorf("unit mismatch")
+        }
+
+        return &Count{Value: c.Value + next.Value, Unit: c.Unit}, nil
+    }
+    if c != nil {
+        return c, nil
+    }
+    if next != nil {
+        return next, nil
+    }
+
+    return nil, nil
+}
+```
+
+## Conclusion
+
+The code becomes safer and often clearer. Benefits of the Null Type pattern:
+
+1. No nil pointer panics from these fields.  
+2. Easier comparison of `comparable` structs (no custom `Equal` with nil branches).
+
+Applying it everywhere can overcomplicate the codebase. It fits primitives and small structs best;
+for large structs, prefer other safe-design techniques.

--- a/content/post/2025-04-go-null-type-pattern/index.md
+++ b/content/post/2025-04-go-null-type-pattern/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Уменьшаем риск nil pointer panic с помощью Null Type pattern'
 slug: 'go-null-type-pattern'
+translationKey: go-null-type-pattern
 date: '2025-04-05'
 categories: ["Программирование"]
 tags: ["Golang", "null", "типизация", "паттерн"]

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -23,16 +23,20 @@ outputs:
 
 # Theme i18n support
 # Available values: ar, bn, ca, de, el, en, es, fr, hu, id, it, ja, ko, nl, pt-br, th, uk, zh-cn, zh-hk, zh-tw
-DefaultContentLanguage: ru
+defaultContentLanguage: ru
 
-#languages:
-#  en:
-#    languageName: English
-#    title: Example Site
-#    weight: 1
-#    params:
-#      sidebar:
-#        subtitle: Example description
+languages:
+  ru:
+    languageName: Русский
+    weight: 1
+  en:
+    languageName: English
+    weight: 2
+    title: Igor Lazarev
+    copyright: Igor Lazarev
+    params:
+      sidebar:
+        subtitle: Notes from a Golang developer
 
 services:
 

--- a/layouts/partials/google_analytics.html
+++ b/layouts/partials/google_analytics.html
@@ -1,1 +1,0 @@
-{{/* Optional: add Google Analytics or other head analytics snippets here. */}}

--- a/layouts/partials/google_analytics.html
+++ b/layouts/partials/google_analytics.html
@@ -1,0 +1,1 @@
+{{/* Optional: add Google Analytics or other head analytics snippets here. */}}

--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -1,0 +1,25 @@
+<meta charset='utf-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
+
+{{- $description := partialCached "data/description" . .RelPermalink -}}
+<meta name='description' {{ printf "content=%q" $description | safeHTMLAttr }}>
+{{ with .Params.Keywords }}<meta name="keywords" content="{{ delimit . ", " }}">{{ end }}
+
+{{- $title := partial "data/title" . -}}
+<title>{{ $title }}</title>
+
+<link rel='canonical' href='{{ .Permalink }}'>
+
+{{- partial "head/style.html" . -}}
+{{- partial "head/script.html" . -}}
+{{- partial "head/opengraph/include.html" . -}}
+
+{{- range .AlternativeOutputFormats -}}
+    <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
+{{- end -}}
+
+{{ with .Site.Params.favicon }}
+    <link rel="shortcut icon" href="{{ . | relURL }}" />
+{{ end }}
+
+{{- partial "head/custom.html" . -}}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Enable Hugo multilingual mode: Russian remains the default language at the site root; English is served under `/en/`.
- Add `translationKey` on the two latest Russian posts and pair them with `index.en.md` translations in the same bundles.
- Add English variants of the main section pages (home menu label, search, about, archives, slides) so the English site navigation matches the Russian one.
- Override `layouts/partials/head/head.html` to match the theme head but **without** the Google Analytics partial (no GA snippet, no empty stub).

## Translated content

- [Новая жизнь журнала на Hugo](content/post/2025-03-12-new-blog-life-with-hugo/) → English in `index.en.md`
- [Null Type pattern](content/post/2025-04-go-null-type-pattern/) → English in `index.en.md`

The English Null Type article links to the nullable-types post on the Russian URL with a “(Russian)” note, since that article has no English version yet.

## Notes

- Theme Stack shows translation links on articles when `.IsTranslated` is true; the sidebar language switcher appears when there is more than one home translation.
- `hugo build` may warn about missing home JSON layout for `en`; search JSON still comes from the search page layout.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa22972a-0440-4974-a424-d422a313dfef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa22972a-0440-4974-a424-d422a313dfef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

